### PR TITLE
Introduced an HTTP Ingest Sample

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,12 @@ buildscript {
             url "https://plugins.gradle.org/m2/"
         }
         jcenter()
+        mavenCentral()
     }
+
     dependencies {
         classpath "com.github.jengelman.gradle.plugins:shadow:1.2.3"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,8 @@ projectVersion=0.1.0-SNAPSHOT
 # Dependency versions
 pravegaVersion=0.1.0
 pravegaConnectorsVersion=0.1.0
+kotlin_version=1.1.4
+dropwizardVersion=1.1.4
 flinkVersion=1.3-SNAPSHOT
 
 ### clusters

--- a/http-ingest/Dockerfile
+++ b/http-ingest/Dockerfile
@@ -7,5 +7,5 @@ EXPOSE 9099 9099
 
 COPY build/lib /app/lib
 COPY build/scripts/http-ingest /app/bin/
-copy dist/config.yml /app
+COPY dist/config.yml /app
 

--- a/http-ingest/Dockerfile
+++ b/http-ingest/Dockerfile
@@ -1,0 +1,11 @@
+FROM openjdk:8-jre
+
+WORKDIR /app
+VOLUME ["/app/log"]
+ENTRYPOINT ["/app/bin/http-ingest", "server", "config.yml"]
+EXPOSE 9099 9099
+
+COPY build/lib /app/lib
+COPY build/scripts/http-ingest /app/bin/
+copy dist/config.yml /app
+

--- a/http-ingest/README.md
+++ b/http-ingest/README.md
@@ -8,7 +8,7 @@ By default the webapp listens on port 9099 but that is configurable. The app pro
 
 ## POST /{scope}/{stream}?key={key}
 
-Ingests the payload into Pravega. This will create the stream if it does not already exist and ingest the raw content of the http payload into Pravega.
+Ingests the payload into Pravega. This will create the stream if it does not already exist and ingest the raw content of the http request body into Pravega.
 
 Parameters:
 
@@ -48,7 +48,7 @@ Then you can run the deploy script to deploy the app to marathon. This script wi
 You can now test out the app by running the following curl command from the Nautilus cluster.
 
 ```
-curl -d "Hello World!" "http://httpingest.marathon.mesos:9099/example/ingest?key=hello"
+curl -d "Hello World!" "http://http-ingest.marathon.mesos:9099/example/ingest?key=hello"
 ```
 
 Try this out using different messages, keys and streams.

--- a/http-ingest/README.md
+++ b/http-ingest/README.md
@@ -2,13 +2,9 @@
 
 This sample illustrates how to build an ingestion gateway as a webapp. The webapp serves a simple API to allow ingesting data into any Pravega stream.
 
-## Running in Nautilus
-
-TODO
-
 # Ingestion API
 
-By default the webapp listens on port 8080 but that is configurable. The app provides a single API method.
+By default the webapp listens on port 9099 but that is configurable. The app provides a single API method.
 
 ## POST /{scope}/{stream}?key={key}
 
@@ -21,3 +17,38 @@ Parameters:
     * stream - The pravega stream to write to is encoded as part of the URL.
 * Query Parameters:
     * key - Optional. The routing key is set via a query parameter.
+
+# Running in Nautilus
+
+You must first have the following pre-requisites installed.
+
+* Nautilus CLI - Available from the Nautilus UI through the user dropdown menu.
+* DC/OS CLI - Available through the DC/OS UI in the menu dropdown.
+
+Both of these tools should be on the path.
+
+First target the Nautilus cluster and login.
+
+```
+nautilus target <TARGET_IP>
+nautilus login
+# .. enter username/password
+```
+
+Ensure you add the Target cluster IP as a docker insecure registry (or 0.0.0.0). This is located in preferences/daemon for docker for mac.
+
+Then you can run the deploy script to deploy the app to marathon. This script will compile the app, create the docker container and deploy it to Nautilus using marathon:
+
+```
+./deploy.sh <TARGET_IP>
+```
+
+## Testing the Webapp
+
+You can now test out the app by running the following curl command from the Nautilus cluster.
+
+```
+curl -d "Hello World!" "http://httpingest.marathon.mesos:9099/example/ingest?key=hello"
+```
+
+Try this out using different messages, keys and streams.

--- a/http-ingest/README.md
+++ b/http-ingest/README.md
@@ -1,0 +1,23 @@
+# Sample Ingestion Webapp
+
+This sample illustrates how to build an ingestion gateway as a webapp. The webapp serves a simple API to allow ingesting data into any Pravega stream.
+
+## Running in Nautilus
+
+TODO
+
+# Ingestion API
+
+By default the webapp listens on port 8080 but that is configurable. The app provides a single API method.
+
+## POST /{scope}/{stream}?key={key}
+
+Ingests the payload into Pravega. This will create the stream if it does not already exist and ingest the raw content of the http payload into Pravega.
+
+Parameters:
+
+* Path Parameters:
+    * scope - The pravega scope to write to is encoded as part of the URL.
+    * stream - The pravega stream to write to is encoded as part of the URL.
+* Query Parameters:
+    * key - Optional. The routing key is set via a query parameter.

--- a/http-ingest/build.gradle
+++ b/http-ingest/build.gradle
@@ -10,3 +10,10 @@ dependencies {
             "io.dropwizard:dropwizard-core:${dropwizardVersion}",
             "io.pravega:pravega-client:${pravegaVersion}"
 }
+
+task assembleLib(type: Copy) {
+    into "${buildDir}/lib"
+    from project.configurations.runtime
+    from project.configurations.runtime.allArtifacts.files
+}
+assemble.dependsOn assembleLib

--- a/http-ingest/build.gradle
+++ b/http-ingest/build.gradle
@@ -1,0 +1,12 @@
+apply plugin: 'java'
+apply plugin: 'kotlin'
+apply plugin: 'application'
+
+mainClassName = 'io.pravega.ingest.IngestApp'
+
+dependencies {
+    compile "org.slf4j:slf4j-api:1.7.3",
+            "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}",
+            "io.dropwizard:dropwizard-core:${dropwizardVersion}",
+            "io.pravega:pravega-client:${pravegaVersion}"
+}

--- a/http-ingest/deploy.sh
+++ b/http-ingest/deploy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+TARGET=$1
+if [ -z "${TARGET}" ]; then
+    echo "Usage: $0 <TARGET_IP>"
+    exit 1
+fi
+
+IMAGE_REPO=httpingest:latest
+
+set +ex
+
+(cd ..; ./gradlew assemble)
+
+docker build -t $IMAGE_REPO .
+docker tag $IMAGE_REPO $TARGET:5000/$IMAGE_REPO
+docker push $TARGET:5000/$IMAGE_REPO
+
+dcos marathon app add httpingest-marathon.json

--- a/http-ingest/deploy.sh
+++ b/http-ingest/deploy.sh
@@ -6,7 +6,7 @@ if [ -z "${TARGET}" ]; then
     exit 1
 fi
 
-IMAGE_REPO=httpingest:latest
+IMAGE_REPO=http-ingest:latest
 
 set +ex
 
@@ -16,4 +16,4 @@ docker build -t $IMAGE_REPO .
 docker tag $IMAGE_REPO $TARGET:5000/$IMAGE_REPO
 docker push $TARGET:5000/$IMAGE_REPO
 
-dcos marathon app add httpingest-marathon.json
+dcos marathon app add http-ingest-marathon.json

--- a/http-ingest/dist/config.yml
+++ b/http-ingest/dist/config.yml
@@ -1,13 +1,12 @@
 server:
   applicationConnectors:
    - type: http
-     port: 8080
+     port: 9099
   adminConnectors:
     - type: http
-      port: 8081
+      port: 9098
 
 logging:
   level: INFO
 
-pravegaControllerUri: "tcp://localhost:9090"
-#pravegaControllerUri: "tcp://controller.pravega.l4lb.thisdcos.directory:9091"
+pravegaControllerUri: "tcp://controller.pravega.l4lb.thisdcos.directory:9091"

--- a/http-ingest/dist/config.yml
+++ b/http-ingest/dist/config.yml
@@ -1,0 +1,13 @@
+server:
+  applicationConnectors:
+   - type: http
+     port: 8080
+  adminConnectors:
+    - type: http
+      port: 8081
+
+logging:
+  level: INFO
+
+pravegaControllerUri: "tcp://localhost:9090"
+#pravegaControllerUri: "tcp://controller.pravega.l4lb.thisdcos.directory:9091"

--- a/http-ingest/http-ingest-marathon.json
+++ b/http-ingest/http-ingest-marathon.json
@@ -6,7 +6,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "master.mesos:5000/httpingest:latest",
+      "image": "master.mesos:5000/http-ingest:latest",
       "network": "HOST",
       "forcePullImage": true
     },

--- a/http-ingest/httpingest-marathon.json
+++ b/http-ingest/httpingest-marathon.json
@@ -1,5 +1,5 @@
 {
-  "id": "/httpingest",
+  "id": "/http-ingest",
   "instances": 1,
   "cpus": 0.1,
   "mem": 1024,

--- a/http-ingest/httpingest-marathon.json
+++ b/http-ingest/httpingest-marathon.json
@@ -1,0 +1,24 @@
+{
+  "id": "/httpingest",
+  "instances": 1,
+  "cpus": 0.1,
+  "mem": 1024,
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "master.mesos:5000/httpingest:latest",
+      "network": "HOST",
+      "forcePullImage": true
+    },
+    "portDefinitions": [
+      {
+        "protocol": "tcp",
+        "port": 9099
+      }
+    ]
+  },
+  "ipAddress": {
+    "networkName": "dcos"
+  }
+}
+

--- a/http-ingest/src/main/kotlin/io/pravega/ingest/ByteArraySerializer.kt
+++ b/http-ingest/src/main/kotlin/io/pravega/ingest/ByteArraySerializer.kt
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.ingest
+
+import io.pravega.client.stream.Serializer
+import java.nio.ByteBuffer
+
+object ByteArraySerializer : Serializer<ByteArray> {
+    override fun deserialize(buf: ByteBuffer): ByteArray {
+        if (buf.hasArray() && buf.arrayOffset() == 0 && buf.position() == 0 && buf.limit() == buf.capacity()) {
+            return buf.array()
+        }
+        else {
+            val bytes = ByteArray(buf.remaining())
+            buf.get(bytes)
+            return bytes
+        }
+    }
+
+    override fun serialize(value: ByteArray): ByteBuffer {
+        return ByteBuffer.wrap(value)
+    }
+}

--- a/http-ingest/src/main/kotlin/io/pravega/ingest/IngestApp.kt
+++ b/http-ingest/src/main/kotlin/io/pravega/ingest/IngestApp.kt
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.ingest
+
+import io.dropwizard.Application
+import io.dropwizard.setup.Environment
+
+class IngestApp : Application<IngestAppConfig>() {
+
+    override fun run(configuration: IngestAppConfig, env: Environment) {
+        val ingestResource = IngestResource(configuration.pravegaControllerUri)
+
+        env.jersey().register(ingestResource)
+    }
+
+    companion object {
+        @JvmStatic fun main(args: Array<String>) {
+            IngestApp().run(*args)
+        }
+    }
+}

--- a/http-ingest/src/main/kotlin/io/pravega/ingest/IngestAppConfig.kt
+++ b/http-ingest/src/main/kotlin/io/pravega/ingest/IngestAppConfig.kt
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.ingest
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.dropwizard.Configuration
+
+class IngestAppConfig: Configuration() {
+    var pravegaControllerUri: String = "tcp://localhost:9090"
+        @JsonProperty set
+}

--- a/http-ingest/src/main/kotlin/io/pravega/ingest/IngestResource.kt
+++ b/http-ingest/src/main/kotlin/io/pravega/ingest/IngestResource.kt
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2017 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.pravega.ingest
+
+import io.pravega.client.ClientFactory
+import io.pravega.client.admin.StreamManager
+import io.pravega.client.stream.EventStreamWriter
+import io.pravega.client.stream.EventWriterConfig
+import io.pravega.client.stream.ScalingPolicy
+import io.pravega.client.stream.StreamConfiguration
+import java.net.URI
+import java.util.concurrent.ConcurrentHashMap
+import javax.ws.rs.*
+import javax.ws.rs.core.Response
+
+@Path("/")
+class IngestResource(controllerUri: String) {
+    private val controllerUri = URI(controllerUri)
+    private val cachedWriters = ConcurrentHashMap<String, EventStreamWriter<ByteArray>>()
+
+    @POST
+    @Path("{scope}/{stream}")
+    fun ingest(@PathParam("scope") scope: String,
+               @PathParam("stream") stream: String,
+               @QueryParam("key") key: String?,
+               body: ByteArray): Response {
+        val writer = cachedWriters.getOrPut("$scope/$stream") {
+            // Create scope
+            val streamManager = StreamManager.create(controllerUri)
+            streamManager.createScope(scope)
+
+            // Create stream
+            val config = StreamConfiguration.builder()
+                    .scope(scope)
+                    .streamName(stream)
+                    .scalingPolicy(ScalingPolicy.fixed(1))
+                    .build()
+            streamManager.createStream(scope, stream, config)
+
+            val clientFactory = ClientFactory.withScope(scope, controllerUri)
+            val eventWriterConfig = EventWriterConfig.builder().build()
+
+            clientFactory.createEventWriter(stream, ByteArraySerializer, eventWriterConfig)
+        }
+        writer.writeEvent(key, body)
+
+        return Response.ok().build()
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,4 +12,4 @@ rootProject.name = 'nautilus-samples'
 
 include 'anomaly-detection'
 include 'sanity-samples'
-
+include 'http-ingest'


### PR DESCRIPTION
Introduce a new sample for Nautilus illustrating how to build an HTTP ingestion gateway. This provides a sample that is easily deployable to Nautilus through marathon that provides a REST API for ingesting data into Pravega. Instructions are provided in the README.md on how to deploy this.

* The sample is written in Kotlin providing another way of consuming the Pravega API
* The sample Listens on port 9099 and can be looked up using mesos-dns at `httpingest.marathon.mesos`
* Ingestion can occur to any Pravega scope or stream with any routing key specified.
* Using this gateway can allow for creating other future samples using non-JVM languages or even curl as shown in the readme.