### PR TITLE
[issue-21] added nautilus credentials dependency to anomaly and sanity test app

### DIFF
--- a/anomaly-detection/build.gradle
+++ b/anomaly-detection/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     compileOnly "org.apache.flink:flink-streaming-java_2.11:${flinkVersion}"
     compileOnly "org.apache.flink:flink-connector-elasticsearch5_2.11:${flinkVersion}"
     shadowRelocate "org.apache.flink:flink-connector-elasticsearch5_2.11:${flinkVersion}"
+    shadowRelocate "com.emc.nautilus:pravega-credentials:${nautilusCredentials}"
 }
 
 shadowJar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@ kotlin_version=1.1.4
 dropwizardVersion=1.1.4
 flinkVersion=1.4.0
 shadowGradlePlugin=2.0.3
+nautilusCredentials=0.6-12583.1e2daee
 
 ### clusters
 dcosAddress=master.mesos

--- a/sanity-samples/build.gradle
+++ b/sanity-samples/build.gradle
@@ -16,19 +16,30 @@ apply plugin: 'com.github.johnrengelman.shadow'
 mainClassName = 'io.pravega.samples.flink.testruns.StandardReaderWriterTest'
 applicationDefaultJvmArgs = ["-Dlog4j.configuration=file:conf/log4j.properties"]
 
+configurations {
+    shadowRelocate {
+    }
+}
+
 dependencies {
     compile "org.slf4j:slf4j-log4j12:1.7.14"
     compile "io.pravega:pravega-connectors-flink_2.11:${pravegaConnectorsVersion}"
     compile "org.apache.flink:flink-streaming-java_2.11:${flinkVersion}"
     compile "org.apache.flink:flink-test-utils_2.11:${flinkVersion}"
+    shadowRelocate "com.emc.nautilus:pravega-credentials:${nautilusCredentials}"
 }
 
 shadowJar {
+    configurations = [project.configurations.runtime, project.configurations.shadowRelocate]
+
     dependencies {
-        include dependency("io.pravega:pravega-connectors-flink_2.11")
+        include dependency("io.pravega:pravega-connectors-flink_2.11:${pravegaConnectorsVersion}")
         include dependency("org.apache.flink:flink-test-utils-junit:${flinkVersion}")
+        include dependency ("com.emc.nautilus:pravega-credentials:${nautilusCredentials}")
         include dependency("junit:junit:4.12")
     }
+    mergeServiceFiles()
+
 }
 
 distributions {


### PR DESCRIPTION
Nautilus credentials implementation (jar) is required to run the anomaly detection application on a secure Pravega cluster (Nautilus Environment). This fix addresses the issue https://github.com/pravega/nautilus-samples/issues/21

Tested and confirmed anomaly application working fine on both secure and clear Nautilus cluster.