### PR TITLE
[issue-23] Update connector and pravega snapshot version to pull from jcenter

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 projectVersion=0.3.0-SNAPSHOT
 
 # Dependency versions
-pravegaConnectorsVersion=0.3.0-104.000cd63-SNAPSHOT
-pravegaVersion=0.3.0-50.929d92e-SNAPSHOT
+pravegaConnectorsVersion=0.3.0-103.ad282e9-SNAPSHOT
+pravegaVersion=0.3.0-50.b5ecb57-SNAPSHOT
 kotlin_version=1.1.4
 dropwizardVersion=1.1.4
 flinkVersion=1.4.0

--- a/standalone-examples/build.gradle
+++ b/standalone-examples/build.gradle
@@ -25,10 +25,13 @@ ext {
 dependencies {
     testCompile "junit:junit:${junitVersion}"
 
-        compile "com.emc.nautilus:pravega-credentials:${nautilusCredentials}",
-                "io.pravega:pravega-client:${pravegaVersion}",
-                "io.pravega:pravega-common:${pravegaVersion}",
-                "commons-cli:commons-cli:${commonsCLIVersion}"
+    if (includeNautilusCredentials.toBoolean()) {
+        compile "com.emc.nautilus:pravega-credentials:${nautilusCredentials}"
+    }
+
+    compile "io.pravega:pravega-client:${pravegaVersion}",
+            "io.pravega:pravega-common:${pravegaVersion}",
+            "commons-cli:commons-cli:${commonsCLIVersion}"
 
     compile "org.slf4j:slf4j-api:1.7.14"
     compile "ch.qos.logback:logback-classic:1.1.7"


### PR DESCRIPTION
Signed-off-by: Vijay Srinivasaraghavan <vijayaraghavan.srinivasaraghavan@emc.com>

This PR addresses the issue https://github.com/pravega/nautilus-samples/pull/26
   * updated pravega and connector version to the latest snapshot version
   * fixed standalone-examples build to conditionally include nautilus credentials jar
